### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
 assignments-old/*
-.ipynb_checkpoints/*
 assign/*
-labs/.ipynb_checkpoints/*
-slides_pdf/.ipynb_checkpoints/*
-notebooks/.ipynb_checkpoints/*
-notebooks/__pycache__/*
-notebooks/mglearn/__pycache__/*
-studies/.ipynb_checkpoints/*
-studies/__pycache__/*
-templates/.ipynb_checkpoints/*
-*/.DS_Store
+.ipynb_checkpoints/
+__pycache__/
 .DS_Store


### PR DESCRIPTION
I noticed that some directories like `labs/__pycache__` were not being ignored.

This change should ignore all `__pycache__` and `.ipynb_checkpoints` directories, even when they are nested in another directory.